### PR TITLE
Add Token cache with redis

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       faraday (~> 0.17.0)
       json (~> 2.2)
       openssl (~> 2.1)
+      redis (~> 4.1, >= 4.1.3)
 
 GEM
   remote: https://rubygems.org/
@@ -24,9 +25,10 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     docile (1.3.2)
-    faraday (0.17.0)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     hashdiff (1.0.0)
+    ipaddr (1.2.2)
     json (2.2.0)
     method_source (0.9.2)
     minitest (5.12.2)
@@ -37,6 +39,7 @@ GEM
       ruby-progressbar
     multipart-post (2.1.1)
     openssl (2.1.2)
+      ipaddr
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -45,6 +48,7 @@ GEM
       pry (~> 0.10)
     public_suffix (4.0.1)
     rake (10.5.0)
+    redis (4.1.3)
     ruby-progressbar (1.10.1)
     safe_yaml (1.0.5)
     simplecov (0.16.1)

--- a/lib/mpesa/mpesamain.rb
+++ b/lib/mpesa/mpesamain.rb
@@ -81,7 +81,7 @@ module Mpesa
 
     def call(path:, body:)
       base_url = Mpesa.configuration.base_url
-      token = Token.call
+      token = Token.new.call
       headers = {
         'Accept': 'application/json',
         'Content-Type': 'application/json',

--- a/lib/mpesa/mpesamain.rb
+++ b/lib/mpesa/mpesamain.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
+require 'token'
 # Main logic
-
 # extends Mpesa module
 module Mpesa
   class << self
@@ -81,7 +81,7 @@ module Mpesa
 
     def call(path:, body:)
       base_url = Mpesa.configuration.base_url
-      token = JSON.parse(Mpesa.access_token.body)['access_token']
+      token = Token.call
       headers = {
         'Accept': 'application/json',
         'Content-Type': 'application/json',

--- a/lib/mpesa/token.rb
+++ b/lib/mpesa/token.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'redis'
+require 'mpesamain'
+# Access Token class
+class Token
+  @redis = Redis.new
+
+  def initialize
+    token = @redis.get('access_token')
+    set_access_token if token.nil?
+  end
+
+  def call
+    @redis.get('access_token')
+  end
+
+  def set_access_token
+    token = JSON.parse(Mpesa.access_token.body)['access_token']
+    @redis.setex('access_token', 3600, token)
+  end
+end

--- a/mpesa.gemspec
+++ b/mpesa.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faraday', '~> 0.17.0'
   spec.add_runtime_dependency 'json', '~> 2.2'
   spec.add_runtime_dependency 'openssl', '~> 2.1'
+  spec.add_runtime_dependency 'redis', '~> 4.1', '>= 4.1.3'
   # request
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'minitest-reporters', '~> 1.4'


### PR DESCRIPTION
- Cache Token with redis.
- Avoid many requests to mpesa server.