### PR TITLE
Convert attributes to hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-### Unreleased
+### 2022-01-04
+- Support `response` `to_hash` method
+### 2020-01-20
 - Update gemspec
 - Read certificate full path
 - Return early if get access token fail

--- a/lib/mpesa/object.rb
+++ b/lib/mpesa/object.rb
@@ -4,6 +4,8 @@ require 'ostruct'
 
 module Mpesa
   class Object
+    attr_reader :attributes
+
     def initialize(attributes)
       @attributes = OpenStruct.new(attributes)
     end
@@ -15,6 +17,10 @@ module Mpesa
 
     def respond_to_missing?(_method, _include_private = false)
       true
+    end
+
+    def to_hash
+      attributes.to_h
     end
   end
 end


### PR DESCRIPTION
Covert response attributes to hash
```
res.to_hash

res.to_hash.to_json 

res.attributes.to_h.to_json
```
Ref https://ruby-doc.org/stdlib-2.5.3/libdoc/ostruct/rdoc/OpenStruct.html#method-i-to_h

closes #14 