### PR TITLE
Convert expires_in value to numeric

### DIFF
--- a/lib/mpesa/resources/token.rb
+++ b/lib/mpesa/resources/token.rb
@@ -20,7 +20,7 @@ module Mpesa
 
     def cache_token
       res = call
-      cache.write('token', res.access_token, expires_in: res.expires_in)
+      cache.write('token', res.access_token, expires_in: res.expires_in.to_i)
       res
     end
 


### PR DESCRIPTION
`expires_in` somehow allowed passing string values but the feature was not documented . This will however throw errors from rails 7.1. 

Convert the value to Numeric to work as expected.

The errors

```
/Users/gathuku/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/activesupport-7.1.1/lib/active_support/cache.rb:866:in `merged_options': undefined method `negative?' for "3599":String (NoMethodError)
```

closed #29 