### PR TITLE
Add support for using till numbers on STK push

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Lipa na mpesa online(Stk Push)
 ```ruby
 response = client.stk(
   shortcode: "174379",
+  # till_no: "379174",
   pass_key: "bfb279f9aa9bdbcf158e97dd71a467cd2e0c893059b10f78e6b72ada1ed2c919", # Optional if passed in client initialization
   amount: "10",
   phone: "254705112855",
@@ -77,6 +78,7 @@ response = client.stk(
 response.CheckoutRequestID # "ws_CO_040920212326513616"
 response.inspect # to see all available attributes
 ```
+If working with a till number, pass it in the `till_no` param. The shortcode should be the HeadOffice(HO)/Store number.
 
 ### STK Query
 

--- a/lib/mpesa/resources/stk.rb
+++ b/lib/mpesa/resources/stk.rb
@@ -25,9 +25,10 @@ module Mpesa
     end
 
     def transaction_details
+      till_no = args[:till_no] unless args[:till_no].nil? || args[:till_no].strip.empty?
       {
-        'TransactionType': args[:till_no].present? ? 'CustomerBuyGoodsOnline' : 'CustomerPayBillOnline',
-        'PartyB': args[:till_no] || shortcode
+        'TransactionType': till_no.nil? ? 'CustomerPayBillOnline' : 'CustomerBuyGoodsOnline',
+        'PartyB': till_no || shortcode
       }
     end
 

--- a/lib/mpesa/resources/stk.rb
+++ b/lib/mpesa/resources/stk.rb
@@ -15,14 +15,19 @@ module Mpesa
         'BusinessShortCode': shortcode,
         'Password': password,
         'Timestamp': timestamp,
-        'TransactionType': 'CustomerPayBillOnline',
         'Amount': args[:amount],
         'PartyA': format_phone(args[:phone]),
-        'PartyB': shortcode,
         'PhoneNumber': format_phone(args[:phone]),
         'CallBackURL': args[:callback_url],
         'AccountReference': args[:reference],
         'TransactionDesc': args[:trans_desc]
+      }.merge(transaction_details)
+    end
+
+    def transaction_details
+      {
+        'TransactionType': args[:till_no].present? ? 'CustomerBuyGoodsOnline' : 'CustomerPayBillOnline',
+        'PartyB': args[:till_no] || shortcode
       }
     end
 

--- a/test/mpesa/client_test.rb
+++ b/test/mpesa/client_test.rb
@@ -3,6 +3,7 @@
 require 'test_helper'
 class ClientTest < MpesaTest
   def test_access_token
+    # skip
     VCR.use_cassette('access_token') do
       response = @client.auth
       refute_nil response.access_token
@@ -10,6 +11,7 @@ class ClientTest < MpesaTest
   end
 
   def test_register_urls
+    # skip
     VCR.use_cassette('register_urls') do
       response = @client.register(
         shortcode: '600998',
@@ -22,6 +24,7 @@ class ClientTest < MpesaTest
 
   # Test B2C payouts
   def test_b2c_payout
+    # skip
     VCR.use_cassette('b2c_payout') do
       response = @client.payout(
         initiator_username: 'testapi',
@@ -41,6 +44,7 @@ class ClientTest < MpesaTest
 
   # Test STK
   def test_stk
+    # skip
     VCR.use_cassette('stk_push') do
       response = @client.stk(
         shortcode: '174379',
@@ -52,6 +56,26 @@ class ClientTest < MpesaTest
       )
       refute_nil response.CheckoutRequestID
     end
+  end
+
+  def test_stk_transaction_type
+    # skip
+    payload = {
+      shortcode: '174379',
+      amount: '10',
+      phone: '0705112855',
+      callback_url: 'https://test.com',
+      reference: 'REF',
+      trans_desc: 'desc'
+    }
+    resource = Mpesa::Stk.new(@client, payload)
+    assert_equal 'CustomerPayBillOnline', resource.body[:TransactionType], 'should default to a paybill transaction'
+    assert_equal payload[:shortcode], resource.body[:PartyB]
+
+    resource = Mpesa::Stk.new(@client, payload.merge({ till_no: '379174' }))
+    assert_equal 'CustomerBuyGoodsOnline', resource.body[:TransactionType],
+                 'should initiate a till payment if till_no provided'
+    assert_equal '379174', resource.body[:PartyB]
   end
 
   def test_status


### PR DESCRIPTION
The stk method now accepts a new param, `till_no`, that sets the correct request parameters for payment to a till number.